### PR TITLE
Add Docker support with Dockerfile and Makefile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app/
+
+COPY . .
+
+RUN go mod download
+RUN go mod verify
+
+RUN CGO_ENABLED=0 go build -o /medguardian/app ./cmd/medguardian/
+
+FROM scratch
+
+COPY --from=builder /medguardian /medguardian
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT [ "/medguardian/app" ]

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,17 @@
 
 .PHONY: build_for_alpine fmt vet build run
 
-build_for_alpine:
-	CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo .
+build_for_alpine: lint
+	CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo ./cmd/medguardian/
+
+build_for_scratch:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app ./cmd/medguardian/
+
+image:
+	docker build -t medguardian:test .
+
+run_container:
+	docker run --rm -d --env-file .env.local medguardian:test
 
 fmt:
 	go fmt ./...


### PR DESCRIPTION
Introduce a Dockerfile for building the application and update the Makefile to include targets for building the Docker image and running the container.