### PR TITLE
Refactor Parser to use LLMClient interface and add unit tests for ParseText function

### DIFF
--- a/internal/texttotime/groq_parser.go
+++ b/internal/texttotime/groq_parser.go
@@ -8,7 +8,11 @@ import (
 )
 
 type Parser struct {
-	llm *groq.Client
+	llm LLMClient
+}
+
+type LLMClient interface {
+	ParseTextToISO8601(text string) (string, error)
 }
 
 func NewParser(apiKey string) *Parser {

--- a/internal/texttotime/groq_parser_test.go
+++ b/internal/texttotime/groq_parser_test.go
@@ -1,0 +1,63 @@
+package texttotime
+
+import (
+	"testing"
+	"time"
+)
+
+type LLMClientStub struct{}
+
+func (llmC *LLMClientStub) ParseTextToISO8601(text string) (string, error) {
+	switch text {
+	case "until 10th Sep 2026":
+		return "2026-09-10", nil
+	case "tomorrow":
+		return time.Now().Add(24 * time.Hour).Format(time.DateOnly), nil
+	case "foo":
+		return "bar", nil
+	}
+	return "", nil
+}
+
+func TestParseText(t *testing.T) {
+	p := Parser{&LLMClientStub{}}
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput time.Time
+		hasError       bool
+	}{
+		{
+			name:           "simple date",
+			input:          "until 10th Sep 2026",
+			expectedOutput: time.Date(2026, time.September, 10, 0, 0, 0, 0, time.UTC),
+			hasError:       false,
+		},
+		{
+			name:           "relative date",
+			input:          "tomorrow",
+			expectedOutput: time.Now().Add(24 * time.Hour).Truncate(24 * time.Hour),
+			hasError:       false,
+		},
+		{
+			name:           "wrong date",
+			input:          "foo",
+			expectedOutput: time.Time{},
+			hasError:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dateISO8601, err := p.ParseText(test.input)
+			if err != nil {
+				if test.hasError == false {
+					t.Errorf("error %v not expected", err)
+				}
+			}
+			if !dateISO8601.Equal(test.expectedOutput) {
+				t.Errorf("expected %s, got %s", test.expectedOutput, dateISO8601)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor the Parser to implement the LLMClient interface, enhancing flexibility. Introduce unit tests for the ParseText function to ensure correct date parsing behavior.